### PR TITLE
add multiple tables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ php artisan vendor:publish --tag="filament-sort-order-config"
 
 This is the contents of the published config file:
 
+// You can incorporate additional tables by appending "table{number}" as an illustration.
+// 'table1' =>'users',
+// 'table2' =>'posts',
+// 'table3' =>'products',
+//And so on...
+
 ```php
 return [
-	'table' => 'users', // Table you want to affect.
-	'sort' => 'asc', // Default sorting.
+    'table1' => 'users', // Specify the table to be affected.
+    // You can incorporate additional tables by appending "table{number}" as an illustration.
+    // 'table2' => 'posts',
+    // 'table3' => 'products',
+    // And so on...
+    'sort' => 'asc', // Default sorting order.
 ];
 ```
 

--- a/config/filament-sort-order.php
+++ b/config/filament-sort-order.php
@@ -1,7 +1,13 @@
 <?php
 
 // config for IbrahimBougaoua/FilamentSortOrder
+// You can incorporate additional tables by appending "table{number}" as an illustration.
+// 'table1' =>'users',
+// 'table2' =>'posts',
+// 'table3' =>'products',
+//And so on...
 return [
-    'table' => 'users',
+    'table1' =>'users',
     'sort' => 'asc',
 ];
+

--- a/database/migrations/create_filament_sort_order_table.php.stub
+++ b/database/migrations/create_filament_sort_order_table.php.stub
@@ -8,10 +8,22 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::table(config('filament-sort-order.table'), function (Blueprint $table) {
-            $table->integer('sort_order')->unsigned()->default(0);
-        });
+        $sortOrder = 1; // Initial sort order value
 
-        DB::table(config('filament-sort-order.table'))->update(['sort_order' => DB::raw('id')]);
+        foreach (config('filament-sort-order') as $key => $table) {
+            if (strpos($key, 'table') === 0) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->integer('sort_order')->unsigned()->default(0);
+                });
+
+                $sortColumn = 'sort_order'; // Change this to the actual column name representing the sort order
+
+                DB::table($table)
+                    ->update([$sortColumn => DB::raw('id')]);
+
+                $sortOrder++; // Increment the sort order for the next table
+            }
+        }
     }
+    
 };


### PR DESCRIPTION
i Modified the return array to include more than one table, incorporating the 'sort_order' column. i Edited the migration files by adding a foreach loop to iterate through all the tables specified in the configuration file.