### PR TITLE
Fix:  Heroicon Icon Setting in UpStepAction::make() & DownStepAction::make() Method

### DIFF
--- a/src/Actions/DownStepAction.php
+++ b/src/Actions/DownStepAction.php
@@ -8,11 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class DownStepAction extends Action
 {
-    protected string|Closure|null $icon = 'heroicon-o-arrow-down';
-
     public static function make(?string $name = 'down'): static
     {
-        return parent::make($name);
+        $instance = parent::make($name);
+        $instance->icon('heroicon-o-arrow-down');
+        return $instance;
     }
 
     protected function setUp(): void

--- a/src/Actions/UpStepAction.php
+++ b/src/Actions/UpStepAction.php
@@ -8,11 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class UpStepAction extends Action
 {
-    protected string|Closure|null $icon = 'heroicon-o-arrow-up';
-
     public static function make(?string $name = 'up'): static
     {
-        return parent::make($name);
+        $instance = parent::make($name);
+        $instance->icon('heroicon-o-arrow-up');
+        return $instance;
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This pull request addresses an issue where the icon was not being set correctly in the UpStepAction & DownStepAction class when the make method was called. The default icon was intended to be heroicon-o-arrow-up of  heroicon-o-arrow-up  , but it was not applied as expected.